### PR TITLE
Fix preview pieces alpha

### DIFF
--- a/src/mino.hpp
+++ b/src/mino.hpp
@@ -9,12 +9,14 @@ struct Application;
 struct Grid;
 
 enum class MinoTransparency : u8 {
+    // here the enum value is used as index into the preview alpha array
     Preview0,
     Preview1,
     Preview2,
     Preview3,
     Preview4,
     Preview5,
+    // here the enum value is used as alpha!
     Ghost = 50,
     Solid = 255,
 };

--- a/src/tetrion.cpp
+++ b/src/tetrion.cpp
@@ -80,7 +80,7 @@ void Tetrion::render(const Application& app) const {
         if (m_preview_tetrominos.at(i)) {
             const auto enum_index = magic_enum::enum_index(MinoTransparency::Preview0);
             if (enum_index.has_value()) {
-                const auto transparency = magic_enum::enum_value<MinoTransparency>(enum_index.value() + 1);
+                const auto transparency = magic_enum::enum_value<MinoTransparency>(enum_index.value() + i);
                 m_preview_tetrominos.at(i)->render(app, m_grid, transparency);
             } else {
                 throw std::exception{}; // unreachable


### PR DESCRIPTION
A commit changed the `+i` to `+1`, which resulted in the wrong index
the commit to blame was [this](https://github.com/mgerhold/oopetris/commit/a26574c4ae91a7ad9a9a385883a9be8723e636aa)