### PR TITLE
bump gcc and clang versions

### DIFF
--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Clang
         uses: egor-tensin/setup-clang@v1
         with:
-          version: 15
+          version: 16
           platform: x64
 
       - name: Prepare compile_commands.json
@@ -38,7 +38,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           style: file
-          version: 15
+          version: 16
           database: build
           files-changed-only: ${{ github.event_name != 'workflow_dispatch' }}
           lines-changed-only: ${{ github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -56,14 +56,14 @@ jobs:
         if: matrix.config.os == 'ubuntu-22.04' && matrix.config.use-clang == true
         uses: egor-tensin/setup-clang@v1
         with:
-          version: 15
+          version: 16
           platform: x64
 
       - name: Setup GCC (Linux)
         if: matrix.config.os == 'ubuntu-22.04' && matrix.config.use-clang == false
         uses: egor-tensin/setup-gcc@v1
         with:
-          version: 12
+          version: 13
           platform: x64
 
       - name: Install dependencies (Linux)


### PR DESCRIPTION
~~bump meson version and remove ugly meson code~~
meson 1.1.1 now supports c++23 as cpp_std option
but since clang and msvc have no std=c++23 flag, it fails :sweat: 

So instead I just bumped gcc and clang to use never versions, with better c++23 (or c++2b) support