### PR TITLE
fix touch input crashing (on android)

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -304,7 +304,8 @@ tl::optional<InputEvent> TouchInput::sdl_event_to_input_event(const SDL_Event& e
 
     if (event.type == SDL_FINGERDOWN) {
         if (m_finger_state.contains(finger_id) and m_finger_state.at(finger_id).has_value()) {
-            throw std::runtime_error{ "A finger was pressed somehow more then once without releasing it in between!" };
+            // there are some valid reasons, this can occur now
+            return tl::nullopt;
         }
 
         const auto x = event.tfinger.x;
@@ -317,7 +318,8 @@ tl::optional<InputEvent> TouchInput::sdl_event_to_input_event(const SDL_Event& e
 
     if (event.type == SDL_FINGERUP) {
         if (!m_finger_state.contains(finger_id) or !m_finger_state.at(finger_id).has_value()) {
-            throw std::runtime_error{ "A finger was released without being pressed!" };
+            // there are some valid reasons, this can occur now
+            return tl::nullopt;
         }
 
         const auto pressed_state = m_finger_state.at(finger_id).value();


### PR DESCRIPTION
- when pressing a button the release event gets handled by the TouchInputs, which "panics"
- this now just returns from the , since it's now totally valid
- otherwise the button would also have to wait until he catches teh release event, which is stupid and doesn't work