### PR TITLE
Fix CPPLint and android build bug

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -51,10 +51,10 @@ jobs:
       - name: Build APK
         run: | 
           cd platforms/android/
-          ./gradlew bundleDebug --no-daemon
+          ./gradlew assembleDebug --no-daemon
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
           name: oopetris.aab
-          path: platforms/android/app/build/outputs/bundle/debug/app-debug.aab
+          path: platforms/android/app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -56,5 +56,5 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: oopetris.aab
-          path: platforms/android/app/build/outputs/apk/debug/app-debug.apk
+          name: oopetris.all-apks
+          path: platforms/android/app/build/outputs/apk/debug/app-*-debug.apk

--- a/platforms/android/app/build.gradle
+++ b/platforms/android/app/build.gradle
@@ -7,7 +7,7 @@ if (buildAsApplication) {
 }
 
 android {
-    compileSdkVersion 34
+    compileSdk 34
     ndkVersion "26.1.10909125"
     defaultConfig {
         if (buildAsApplication) {

--- a/platforms/android/app/build.gradle
+++ b/platforms/android/app/build.gradle
@@ -15,16 +15,13 @@ android {
         }
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 2
-        versionName "1.0.2"
+        versionCode 3
+        versionName "1.0.3"
         externalNativeBuild {
             ndkBuild {
                 arguments "APP_PLATFORM=android-34"
                 abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
             }
-        }
-        ndk {
-            abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
         }
     }
     buildTypes {
@@ -63,6 +60,22 @@ android {
             }
         }
     }
+    splits {
+        // Configures multiple APKs based on ABI.
+        abi {
+            // Enables building multiple APKs per ABI.
+            enable true
+            // By default all ABIs are included, so use reset() and include to specify that you only
+            // want APKs for the ones with a ndk variant (4, android did in the past support more: https://developer.android.com/ndk/guides/abis.html#sa)
+            // Resets the list of ABIs for Gradle to create APKs for to none.
+            reset()
+            // Specifies a list of ABIs for Gradle to create APKs for.
+            include 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
+            // Specifies that you don't want to also generate a universal APK that includes all ABIs.
+            universalApk false
+        }
+    }
+
 }
 
 dependencies {

--- a/platforms/android/gradle/wrapper/gradle-wrapper.properties
+++ b/platforms/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Aug 19 23:33:07 CEST 2023
+#Tue Jan 02 02:01:38 CET 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/platforms/build-android.sh
+++ b/platforms/build-android.sh
@@ -259,6 +259,3 @@ for IDX in "${!DESC_ARRAY[@]}"; do
     cp -r "./assets/icon/icon_$RES.png" "${DESC_DIR}/ic_launcher.png"
 
 done
-
-
-# TODO: build seperate apks for all 4 architectures!

--- a/platforms/build-android.sh
+++ b/platforms/build-android.sh
@@ -156,10 +156,17 @@ for INDEX in "${!ARCH_KEYS[@]}"; do
 
     cd "$LAST_DIR"
 
+    MESON_CPU_FAMILY=$ARCH
+
+    ## this is a flaw in the abis.json, everything is labelled with aarch64 and not arm64, but the "arch" json value is wrong, and meson (https://mesonbuild.com/Reference-tables.html#cpu-families) only knows aarch64!
+    if [[ $MESON_CPU_FAMILY = "arm64" ]]; then
+        MESON_CPU_FAMILY="aarch64"
+    fi
+
     cat <<EOF >"./platforms/crossbuild-android-$ARM_TARGET_ARCH.ini"
 [host_machine]
 system = 'android'
-cpu_family = '$ARCH'
+cpu_family = '$MESON_CPU_FAMILY'
 cpu = '$ARM_VERSION'
 endian = 'little'
 

--- a/platforms/build-android.sh
+++ b/platforms/build-android.sh
@@ -259,3 +259,6 @@ for IDX in "${!DESC_ARRAY[@]}"; do
     cp -r "./assets/icon/icon_$RES.png" "${DESC_DIR}/ic_launcher.png"
 
 done
+
+
+# TODO: build seperate apks for all 4 architectures!


### PR DESCRIPTION
- fix cpplint CI
- fix a long standing android bug, that didn't use aarch64 and 64 bit in an android ABI, this was caused by some naming errors in the Android C++ toolchain, since arm64 is no valid cpu_family according to meson, but aarch64 is.
 this speeds up the runtime execution time, since it's now compiling the c++ part in 64 bit and with modern process stuff enabled, since its armv8 and not armv7
 - this adds apk splitting to the CI and the android project, so that you can install the correct apk, this comes with smaller over-all apk sizes, but no uniform apk, that can be added later  (if needed)