### PR TITLE
Fix some small bugs

### DIFF
--- a/src/capabilities.hpp
+++ b/src/capabilities.hpp
@@ -130,12 +130,13 @@ namespace utils {
 #else
         switch (action) {
             case CrossPlatformAction::OK:
-                return "Return";
+                return "Enter";
             case CrossPlatformAction::PAUSE:
-                return "ESC";
+                return "Esc";
             case CrossPlatformAction::UNPAUSE:
+                return "Esc";
             case CrossPlatformAction::EXIT:
-                return "Return";
+                return "Enter";
             case CrossPlatformAction::DOWN:
                 return "Down";
             case CrossPlatformAction::UP:

--- a/src/scenes/ingame/ingame.cpp
+++ b/src/scenes/ingame/ingame.cpp
@@ -240,7 +240,7 @@ namespace scenes {
 
     [[nodiscard]] bool Ingame::handle_event(const SDL_Event& event) {
 
-        if (utils::event_is_action(event, utils::CrossPlatformAction::PAUSE)) {
+        if (utils::event_is_action(event, utils::CrossPlatformAction::PAUSE) and not is_game_over()) {
             m_should_pause = true;
             return true;
         }


### PR DESCRIPTION
I found some small bugs, that annoyed me:
- [x] When in game over state, the pause menu still displays, over the game over text:
![image](https://github.com/mgerhold/oopetris/assets/32566573/b0ad7e89-e0e2-428d-825c-56458615e9ef)
- [x] Some labels are not correct for the pause screen ("Return" instead of "Esc" and "Return" instead of "Enter")
![image](https://github.com/mgerhold/oopetris/assets/32566573/b9dfa859-65d4-457a-9603-c668cd531659)
