### PR TITLE
Remove old temporary windows patch

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -30,12 +30,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install meson
 
-      # see sdl2.wrap and the issue link in there, it is a problem on windows, and therefore it has to be enabled only in android, where it suceeds
-      - name: Temporary fix
-        run: |
-          sed -i 's/# diff_files/diff_files/g' subprojects/sdl2.wrap 
-          sed -i 's/# diff_files/diff_files/g' subprojects/magic_enum.wrap 
-
       - name: Setup ninja
         run: |
             sudo apt-get update

--- a/subprojects/magic_enum.wrap
+++ b/subprojects/magic_enum.wrap
@@ -5,8 +5,7 @@ source_filename = magic_enum-v0.9.5.tar.gz
 source_hash = 44ad80db5a72f5047e01d90e18315751d9ac90c0ab42cbea7a6f9ec66a4cd679
 source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/magic_enum_0.9.5-1/magic_enum-v0.9.5.tar.gz
 wrapdb_version = 0.9.5-1
-## deactivated by default, see https://github.com/mesonbuild/meson/issues/12092
-# diff_files = magic_enum_android.diff
+diff_files = magic_enum_android.diff
 
 
 [provide]

--- a/subprojects/sdl2.wrap
+++ b/subprojects/sdl2.wrap
@@ -8,8 +8,7 @@ patch_url = https://wrapdb.mesonbuild.com/v2/sdl2_2.28.5-1/get_patch
 patch_hash = 5d5f23359a841111e9b72060686a3ad8c4bf1eb4b338a36bdcdd4d37129d596c
 source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/sdl2_2.28.5-1/SDL2-2.28.5.tar.gz
 wrapdb_version = 2.28.5-1
-## deactivated by default, see https://github.com/mesonbuild/meson/issues/12092
-# diff_files = SDL2-2.28.5_android.diff
+diff_files = SDL2-2.28.5_android.diff
 
 [provide]
 sdl2 = sdl2_dep


### PR DESCRIPTION
In meson 1.3.2 https://github.com/mesonbuild/meson/issues/12092 was fixed (https://github.com/mesonbuild/meson/pull/12443)
This allows to remove the temporary fix I added