### PR TITLE
ci: add arm64 windows runner + MSYS2 clang + clangarm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,14 @@ jobs:
             shell: bash
             fatal_warnings: true
 
+          - name: Linux Clang (libc++, ARM64)
+            os: ubuntu
+            os-version: 24.04-arm
+            use-clang: true
+            use-clang_stdlib: true
+            shell: bash
+            fatal_warnings: true
+
           - name: MacOS
             os: macos
             os-version: 13

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,19 +31,47 @@ jobs:
             static: true
             fatal_warnings: false # TODO: enable fatal warnings, once cpp-httplib is patched either by ourselves or by the maintainers
 
-          - name: Windows MingGW
+          - name: Windows MSVC (ARM64, static)
+            os: windows
+            os-version: 11-arm
+            environment: msvc
+            shell: pwsh
+            static: true
+            fatal_warnings: false # TODO: enable fatal warnings, once cpp-httplib is patched either by ourselves or by the maintainers
+
+          - name: Windows MSYS2 (MingGW)
             os: windows
             os-version: 2025
-            environment: mingw
+            environment: msys2
+            msystem: MINGW64
             architecture: x86_64
             shell: 'msys2 {0}'
             fatal_warnings: true
 
-          - name: Windows UCRT
+          - name: Windows MSYS2 (UCRT)
             os: windows
             os-version: 2025
-            environment: ucrt
+            environment: msys2
+            msystem: UCRT64
             architecture: ucrt-x86_64
+            shell: 'msys2 {0}'
+            fatal_warnings: true
+
+          - name: Windows MSYS2 (CLANG)
+            os: windows
+            os-version: 2025
+            environment: msys2
+            msystem: CLANG64
+            architecture: clang-x86_64
+            shell: 'msys2 {0}'
+            fatal_warnings: true
+
+          - name: Windows MSYS2 (ARM64, CLANG)
+            os: windows
+            os-version: 11-arm
+            environment: msys2
+            msystem: CLANGARM64
+            architecture: clang-x86_64
             shell: 'msys2 {0}'
             fatal_warnings: true
 
@@ -112,10 +140,10 @@ jobs:
           toolset: '14.44'
 
       - name: Setup MSYS2 (Windows)
-        if: matrix.config.os == 'windows' && ( matrix.config.environment == 'mingw' || matrix.config.environment == 'ucrt' )
+        if: matrix.config.os == 'windows' && matrix.config.environment == 'msys2'
         uses: msys2/setup-msys2@v2
         with:
-          msystem: ${{matrix.config.environment == 'mingw' && 'MINGW64' || 'UCRT64'}}
+          msystem: ${{matrix.config.msystem}}
           update: true
           install: >-
             mingw-w64-${{matrix.config.architecture}}-ninja
@@ -131,10 +159,12 @@ jobs:
             git
 
       - name: Setup GCC (MSYS2)
-        if: matrix.config.os == 'windows' && ( matrix.config.environment == 'mingw' || matrix.config.environment == 'ucrt' )
+        if: matrix.config.os == 'windows' && matrix.config.environment == 'msys2'
         uses: Totto16/msys2-install-packages-pinned@v1
         with:
-          msystem: ${{matrix.config.environment == 'mingw' && 'MINGW64' || 'UCRT64'}}
+          msystem: ${{matrix.config.msystem}}
+          # gcc-libs 14 don't provide the virtual package cc-libs, only gcc-libs 15 (see https://github.com/msys2/MINGW-packages/commit/9fa882f7eb6f639780a13df016497a93e45544ac) provide it, so until we use gcc 15, nghttp3 < 1.10.1 needs to be used (see https://github.com/msys2/MINGW-packages/commit/16b7f94772f29f1c207764701d863d266a5de64c) since 1.10.1 needs cc-libs and not gcc-libs. The newest version matching that constraint is 1.9.0
+          # for the other pavckages see https://github.com/msys2/MINGW-packages/commit/62308009e77d772a126313626b194e503b0e5135
           install: |
             gcc=15 gcc-libs=!
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,7 @@ jobs:
         if: matrix.config.os == 'windows' && matrix.config.environment == 'msvc'
         uses: TheMrMilchmann/setup-msvc-dev@v3
         with:
-          arch: ${{matrix.config.os-version == '11-arm' && 'x64' || 'x64'}} # note this action doesn't really support arm64 yet, but it works like this already (by accident)
+          arch: ${{matrix.config.os-version == '11-arm' && 'x64' || 'x64'}} # TODO:fix this action: note this action doesn't really support arm64 yet, but it works like this already (by accident)
           toolset: '14.44'
 
       - name: Setup MSYS2 (Windows)
@@ -209,7 +209,7 @@ jobs:
         uses: egor-tensin/setup-gcc@v1
         with:
           version: 14
-          platform: ${{matrix.config.os-version == '24.04-arm' && 'x64' || 'x64'}} # note this action doesn't really support arm64 yet, but it works like this already (by accident)
+          platform: ${{matrix.config.os-version == '24.04-arm' && 'x64' || 'x64'}} # TODO:fix this action: note this action doesn't really support arm64 yet, but it works like this already (by accident)
 
       - name: Unbreak Python in GHA (MacOS 13 image)
         if: matrix.config.os == 'macos' && matrix.config.os-version == 13

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,7 @@ jobs:
             environment: msys2
             msystem: MINGW64
             architecture: x86_64
+            use-clang: false
             shell: 'msys2 {0}'
             fatal_warnings: true
 
@@ -54,6 +55,7 @@ jobs:
             environment: msys2
             msystem: UCRT64
             architecture: ucrt-x86_64
+            use-clang: false
             shell: 'msys2 {0}'
             fatal_warnings: true
 
@@ -63,6 +65,7 @@ jobs:
             environment: msys2
             msystem: CLANG64
             architecture: clang-x86_64
+            use-clang: true
             shell: 'msys2 {0}'
             fatal_warnings: true
 
@@ -72,6 +75,7 @@ jobs:
             environment: msys2
             msystem: CLANGARM64
             architecture: clang-x86_64
+            use-clang: true
             shell: 'msys2 {0}'
             fatal_warnings: true
 
@@ -161,7 +165,7 @@ jobs:
             git
 
       - name: Setup GCC (MSYS2)
-        if: matrix.config.os == 'windows' && matrix.config.environment == 'msys2'
+        if: matrix.config.os == 'windows' && matrix.config.environment == 'msys2' && matrix.config.use-clang == false
         uses: Totto16/msys2-install-packages-pinned@v1
         with:
           msystem: ${{matrix.config.msystem}}
@@ -170,7 +174,16 @@ jobs:
           install: |
             gcc=15 gcc-libs=!
 
-      - name: Setup Clang (Linux) (libc++)
+      - name: Setup Clang (MSYS2, libc++)
+        if: matrix.config.os == 'windows' && matrix.config.environment == 'msys2' && matrix.config.use-clang == true
+        uses: Totto16/msys2-install-packages-pinned@v1
+        with:
+          msystem: ${{matrix.config.msystem}}
+          install: |
+            clang=20
+            libc++=20
+
+      - name: Setup Clang (Linux, libc++)
         if: matrix.config.os == 'ubuntu' && matrix.config.use-clang == true && matrix.config.use-clang_stdlib
         run: |
           wget https://apt.llvm.org/llvm.sh
@@ -181,7 +194,7 @@ jobs:
           echo "CXX=clang++-20" >> "$GITHUB_ENV"
           echo "OBJC=clang-20" >> "$GITHUB_ENV"
 
-      - name: Setup Clang (Linux) (libstdc++)
+      - name: Setup Clang (Linux, libstdc++)
         if: matrix.config.os == 'ubuntu' && matrix.config.use-clang == true && (! matrix.config.use-clang_stdlib)
         run: |
           wget https://apt.llvm.org/llvm.sh
@@ -248,7 +261,7 @@ jobs:
           brew install sdl2 sdl2_ttf sdl2_mixer sdl2_image
 
       - name: Configure
-        run: meson setup build -Dbuildtype=release -Ddefault_library=${{( matrix.config.os == 'windows' && matrix.config.environment == 'msvc' && matrix.config.static ) && 'static' ||'shared' }} -Dclang_libcpp=${{ ( ( matrix.config.os == 'ubuntu' && matrix.config.use-clang == true && matrix.config.use-clang_stdlib ) || matrix.config.os == 'macos' ) && 'enabled' || 'disabled' }} -Drun_in_ci=true ${{( matrix.config.fatal_warnings ) && '--fatal-meson-warnings' || '' }}
+        run: meson setup build -Dbuildtype=release -Ddefault_library=${{( matrix.config.os == 'windows' && matrix.config.environment == 'msvc' && matrix.config.static ) && 'static' ||'shared' }} -Dclang_libcpp=${{ ( ( matrix.config.os == 'ubuntu' && matrix.config.use-clang == true && matrix.config.use-clang_stdlib ) || matrix.config.os == 'macos' || ( matrix.config.os == 'windows' && matrix.config.environment == 'msys2' && matrix.config.use-clang == true ) ) && 'enabled' || 'disabled' }} -Drun_in_ci=true ${{( matrix.config.fatal_warnings ) && '--fatal-meson-warnings' || '' }}
 
       - name: Build
         run: meson compile -C build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,6 @@ jobs:
             os: ubuntu
             os-version: 24.04-arm
             use-clang: false
-            arm: true
             shell: bash
             fatal_warnings: true
 
@@ -87,7 +86,6 @@ jobs:
             os: ubuntu
             os-version: 24.04
             use-clang: false
-            arm: false
             shell: bash
             fatal_warnings: true
 
@@ -96,7 +94,6 @@ jobs:
             os-version: 24.04
             use-clang: true
             use-clang_stdlib: false
-            arm: false
             shell: bash
             fatal_warnings: true
 
@@ -105,21 +102,18 @@ jobs:
             os-version: 24.04
             use-clang: true
             use-clang_stdlib: true
-            arm: false
             shell: bash
             fatal_warnings: true
 
           - name: MacOS
             os: macos
             os-version: 13
-            arm: false
             shell: bash
             fatal_warnings: true
 
           - name: MacOS (Arm64)
             os: macos
             os-version: 15
-            arm: true
             shell: bash
             fatal_warnings: true
 
@@ -136,7 +130,7 @@ jobs:
         if: matrix.config.os == 'windows' && matrix.config.environment == 'msvc'
         uses: TheMrMilchmann/setup-msvc-dev@v3
         with:
-          arch: x64
+          arch: ${{matrix.config.os-version == '11-arm' && 'x64' || 'x64'}} # note this action doesn't really support arm64 yet, but it works like this already (by accident)
           toolset: '14.44'
 
       - name: Setup MSYS2 (Windows)
@@ -194,7 +188,7 @@ jobs:
         uses: egor-tensin/setup-gcc@v1
         with:
           version: 14
-          platform: x64
+          platform: ${{matrix.config.os-version == '24.04-arm' && 'x64' || 'x64'}} # note this action doesn't really support arm64 yet, but it works like this already (by accident)
 
       - name: Unbreak Python in GHA (MacOS 13 image)
         if: matrix.config.os == 'macos' && matrix.config.os-version == 13

--- a/tools/options/meson.build
+++ b/tools/options/meson.build
@@ -83,7 +83,7 @@ if get_option('run_in_ci')
             'compilers': [msvc_compiler_current],
         },
         'msys2': {
-            'compilers': [gcc_15_compiler],
+            'compilers': [clang_20_compiler, gcc_14_compiler],
         },
         'linux': {
             'compilers': [clang_20_compiler, gcc_14_compiler],


### PR DESCRIPTION
Windows ARM64 runner image is already available since April, see [here](https://github.blog/changelog/2025-04-14-windows-arm64-hosted-runners-now-available-in-public-preview/).

Blocked by these things:
- [ ] libpng not working with (atm only msvc) arm64 (see [cmakelist](https://github.com/pnggroup/libpng/blob/v1.6.48/CMakeLists.txt#L182C1-L182C46) and the wrap does the same (atm)), possibly related to the runner issue, as it maybe doesn't correctly define arm defines, that `\include\arm_neon.h:21` expects
- [ ] visual studio code (msvc) installation issue cl reports x64 as architecture, see also https://github.com/actions/partner-runner-images/issues/86
- [ ] the action `TheMrMilchmann/setup-msvc-dev@v3` doesn't correctly support c64 atm, make Pr, it seems to work right now, but it might not work forever
- [x] the action `Totto16/msys2-install-packages-pinned` doesn't work with installing `libc++`
- [ ] python-pip doesn't work on arm64 and msys2
- [ ] spdlog needs to be patched, to detect clang msys2 correctly and define macros correctly
